### PR TITLE
Add Linux support for HOI4

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,44 @@ Patcher modifying only currently existing game executable, if Paradox release ne
 2. Unzip it in game directory (right click on game on steam > Manage > Browse local files). `universal-checksum-patcher.exe` should be next to your `eu4.exe` or `hoi4.exe`
 3. Run `universal-checksum-patcher.exe`
 
+# Linux usage (native HOI4)
+
+Recommended: download prebuilt binary from Releases:
+- `universal-checksum-patcher-linux-amd64`
+
+Run it from terminal:
+```bash
+chmod +x universal-checksum-patcher-linux-amd64
+./universal-checksum-patcher-linux-amd64
+```
+
+Build from source (alternative):
+```bash
+go build -o universal-checksum-patcher .
+```
+
+Then run:
+```bash
+./universal-checksum-patcher
+```
+
+Interactive mode shows:
+- auto-detected HOI4 installs (when found)
+- selection of executable to patch
+- confirmation prompt before patching
+
+CLI fallback mode:
+```bash
+./universal-checksum-patcher -dir "/run/media/<user>/<drive-id>/SteamLibrary/steamapps/common/Hearts of Iron IV"
+```
+
+Note: launching from a file manager may not show interactive prompts; use a terminal.
+
+and writes a backup next to the executable as `hoi4.backup`.
+
 # Supported games and platforms
 |                       | Windows                | Linux(native) | MacOS  |
 |-----------------------|------------------------|---------------|--------|
 | Europa Universalis IV | Yes :heavy_check_mark: | No :x:        | No :x: |
 | Europa Universalis V  | Yes :heavy_check_mark: | No :x:        | No :x: |
-| Hearts of Iron IV     | Yes :heavy_check_mark: | No :x:        | No :x: |
+| Hearts of Iron IV     | Yes :heavy_check_mark: | Yes :heavy_check_mark: | No :x: |

--- a/error.go
+++ b/error.go
@@ -3,6 +3,8 @@ package main
 import "errors"
 
 var (
-	errNoMatch    = errors.New("cannot detect bytes pattern to patch. Most likely patcher are outdated due to game updates or pather already was applied")
-	errCantLocate = errors.New("cannot locate file in current directory")
+	errNoMatch                 = errors.New("cannot detect bytes pattern to patch. Most likely patcher are outdated due to game updates or pather already was applied")
+	errCantLocate              = errors.New("cannot locate supported game executable")
+	errUnsupportedExecutable   = errors.New("unsupported executable")
+	errUnsupportedBinaryFormat = errors.New("unsupported binary format")
 )

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/IlliaYalovoi/universal-checksum-patcher
 
 go 1.24
+
+require github.com/manifoldco/promptui v0.9.0
+
+require (
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+	golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
+github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b h1:MQE+LT/ABUuuvEZ+YQAMSXindAdUh7slEmAkup74op4=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/hex.go
+++ b/hex.go
@@ -20,9 +20,19 @@ var (
 	replacementEU5    = []byte{0x31, 0xC0, 0x0F, 0x94, 0xC1, 0x88}
 	replacementLength = len(replacement)
 
-	replacementMap = map[string][]byte{
-		eu4:  replacement,
-		eu5:  replacementEU5,
-		hoi4: replacement,
+	replacementMapPE = map[string][]byte{
+		eu4exe:  replacement,
+		eu5exe:  replacementEU5,
+		hoi4exe: replacement,
 	}
+
+	replacementMapELF = map[string][]byte{
+		eu4bin:  replacement,
+		eu5bin:  replacementEU5,
+		hoi4bin: replacement,
+	}
+
+	// Native HOI4 ELF sequence where bytes [2:] are patched from:
+	// 85 C0 0F 94 C3 E8 -> 31 C0 0F 94 C3 E8
+	elfHOI4Needle = []byte{0x31, 0xDB, 0x85, 0xC0, 0x0F, 0x94, 0xC3, 0xE8}
 )

--- a/main.go
+++ b/main.go
@@ -1,60 +1,115 @@
 package main
 
 import (
+	"flag"
 	"fmt"
+	"runtime"
+	"github.com/manifoldco/promptui"
 )
 
 const (
-	eu4  = "eu4.exe"
-	eu5  = "eu5.exe"
-	hoi4 = "hoi4.exe"
+	eu4exe  = "eu4.exe"
+	eu5exe  = "eu5.exe"
+	hoi4exe = "hoi4.exe"
+	eu4bin  = "eu4"
+	eu5bin  = "eu5"
+	hoi4bin = "hoi4"
 )
 
 var (
 	l    *logger
 	exes = map[string]bool{
-		eu4:  true,
-		eu5:  true,
-		hoi4: true,
+		eu4exe:  true,
+		eu5exe:  true,
+		hoi4exe: true,
+		eu4bin:  true,
+		eu5bin:  true,
+		hoi4bin: true,
 	}
 )
 
 func main() {
 	l = newLogger()
+	searchDir := flag.String("dir", "", "directory to search for game executable(s)")
+	flag.Parse()
 
-	func() {
-		filesInDir, err := getFilesInCurrentDir()
-		if err != nil {
+	if *searchDir != "" {
+		if err := runNonInteractive(*searchDir); err != nil {
 			l.Error(err)
-			return
 		}
-
-		filesToPatch := make([]string, 0)
-		for _, file := range filesInDir {
-			if exes[file] {
-				l.Infof("found %s in current directory", file)
-				filesToPatch = append(filesToPatch, file)
-			}
+	} else {
+		if err := runInteractive(); err != nil {
+			l.Error(err)
 		}
+	}
 
-		if len(filesToPatch) == 0 {
-			l.Error(errCantLocate)
-			return
-		}
-
-		for _, file := range filesToPatch {
-			l.Infof("patching %s", file)
-			err = applyPatch(file)
-			if err != nil {
-				l.Error(err)
-				l.Info("patch wasn't installed, no file have been changed")
-				return
-			}
-			l.Infof("patch successfully installed, original executable has been backed up in %s.backup", file)
-		}
-
-	}()
+	if runtime.GOOS != "windows" {
+		return
+	}
 
 	l.Info("press enter to exit...")
 	_, _ = fmt.Scanln()
+}
+
+func runNonInteractive(searchDir string) error {
+	filesToPatch, err := findFilesToPatch(searchDir)
+	if err != nil {
+		return err
+	}
+	if len(filesToPatch) == 0 {
+		return errCantLocate
+	}
+
+	for _, file := range filesToPatch {
+		l.Infof("patching %s", file)
+		err = applyPatch(file)
+		if err != nil {
+			l.Info("patch wasn't installed, no file have been changed")
+			return err
+		}
+		l.Infof("patch successfully installed, original executable has been backed up in %s.backup", file)
+	}
+
+	return nil
+}
+
+func runInteractive() error {
+	filesToPatch, err := findFilesToPatch("")
+	if err != nil {
+		return err
+	}
+	if len(filesToPatch) == 0 {
+		return errCantLocate
+	}
+
+	selector := promptui.Select{
+		Label: "Select executable to patch",
+		Items: filesToPatch,
+		Size:  10,
+	}
+
+	index, _, err := selector.Run()
+	if err != nil {
+		return fmt.Errorf("interactive selection cancelled: %w", err)
+	}
+
+	selected := filesToPatch[index]
+	confirm := promptui.Prompt{
+		Label:     fmt.Sprintf("Patch %s", selected),
+		IsConfirm: true,
+		Default:   "n",
+	}
+
+	if _, err := confirm.Run(); err != nil {
+		return fmt.Errorf("patch cancelled")
+	}
+
+	l.Infof("patching %s", selected)
+	if err := applyPatch(selected); err != nil {
+		l.Info("patch wasn't installed, no file have been changed")
+		return err
+	}
+	l.Infof("patch successfully installed, original executable has been backed up in %s.backup", selected)
+
+	return nil
 }

--- a/patch.go
+++ b/patch.go
@@ -1,9 +1,19 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+)
+
+type binaryKind int
+
+const (
+	binaryKindUnknown binaryKind = iota
+	binaryKindPE
+	binaryKindELF
 )
 
 func applyPatch(filename string) error {
@@ -17,7 +27,15 @@ func applyPatch(filename string) error {
 		return fmt.Errorf("failed to read file: %w", err)
 	}
 
-	err = modifyBytes(filename, bytes)
+	kind := detectBinaryKind(bytes)
+	switch kind {
+	case binaryKindPE:
+		err = patchPE(filename, bytes)
+	case binaryKindELF:
+		err = patchELF(filename, bytes)
+	default:
+		err = errUnsupportedBinaryFormat
+	}
 	if err != nil {
 		return fmt.Errorf("failed to modify bytes: %w", err)
 	}
@@ -44,6 +62,60 @@ func applyPatch(filename string) error {
 	return nil
 }
 
+func detectBinaryKind(bytes []byte) binaryKind {
+	if len(bytes) >= 4 &&
+		bytes[0] == 0x7f &&
+		bytes[1] == 'E' &&
+		bytes[2] == 'L' &&
+		bytes[3] == 'F' {
+		return binaryKindELF
+	}
+
+	if len(bytes) >= 2 &&
+		bytes[0] == 'M' &&
+		bytes[1] == 'Z' {
+		return binaryKindPE
+	}
+
+	return binaryKindUnknown
+}
+
+func patchPE(filename string, bytes []byte) error {
+	return modifyBytes(filename, bytes, replacementMapPE)
+}
+
+func patchELF(filename string, bytes []byte) error {
+	exeName := filepath.Base(filename)
+	if exeName == hoi4bin {
+		return patchELFHoi4(bytes)
+	}
+
+	return modifyBytes(filename, bytes, replacementMapELF)
+}
+
+func patchELFHoi4(data []byte) error {
+	matchesCount := 0
+	searchFrom := 0
+
+	for {
+		idx := bytes.Index(data[searchFrom:], elfHOI4Needle)
+		if idx < 0 {
+			break
+		}
+		idx += searchFrom
+		patchOffset := idx + 2
+		copy(data[patchOffset:patchOffset+replacementLength], replacement)
+		matchesCount++
+		searchFrom = idx + len(elfHOI4Needle)
+	}
+
+	if matchesCount == 0 {
+		return errNoMatch
+	}
+
+	return nil
+}
+
 func isStartCandidate(bytes []byte) bool {
 	return isSlicesEqual(bytes, start1) ||
 		isSlicesEqual(bytes, start2) ||
@@ -56,7 +128,13 @@ func isEndCandidate(bytes []byte) bool {
 		isSlicesEqual(bytes, endEU5)
 }
 
-func modifyBytes(filename string, bytes []byte) error {
+func modifyBytes(filename string, bytes []byte, replacementMap map[string][]byte) error {
+	exeName := filepath.Base(filename)
+	replacementBytes, ok := replacementMap[exeName]
+	if !ok {
+		return errUnsupportedExecutable
+	}
+
 	matchesCount := 0
 	bytesLength := len(bytes)
 
@@ -65,7 +143,7 @@ func modifyBytes(filename string, bytes []byte) error {
 			for j := i + startLength; j <= i+startLength+limit && j <= bytesLength-endLength; j++ {
 				if isEndCandidate(bytes[j : j+endLength]) {
 					l.Tracef("found match #%d", matchesCount+1)
-					copy(bytes[j:j+replacementLength], replacementMap[filename])
+					copy(bytes[j:j+replacementLength], replacementBytes)
 					matchesCount++
 					break
 				}

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 func backupFile(original string) error {
@@ -55,4 +56,93 @@ func getFilesInCurrentDir() ([]string, error) {
 	}
 
 	return result, nil
+}
+
+func findFilesToPatch(overrideDir string) ([]string, error) {
+	roots := []string{"."}
+	if overrideDir != "" {
+		roots = []string{overrideDir}
+	} else {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			roots = append(
+				roots,
+				filepath.Join(home, ".local", "share", "Steam", "steamapps", "common"),
+				filepath.Join(home, ".steam", "steam", "steamapps", "common"),
+				filepath.Join(home, ".var", "app", "com.valvesoftware.Steam", ".local", "share", "Steam", "steamapps", "common"),
+			)
+		}
+
+		roots = append(roots, findMountedSteamCommonDirs()...)
+	}
+
+	found := make([]string, 0)
+	seen := make(map[string]bool)
+
+	for _, root := range roots {
+		_, err := os.Stat(root)
+		if err != nil {
+			continue
+		}
+
+		err = filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return nil
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if !exes[d.Name()] {
+				return nil
+			}
+
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				absPath = path
+			}
+			if seen[absPath] {
+				return nil
+			}
+
+			seen[absPath] = true
+			found = append(found, absPath)
+			l.Infof("found %s", absPath)
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to walk %s: %w", root, err)
+		}
+	}
+
+	return found, nil
+}
+
+func findMountedSteamCommonDirs() []string {
+	patterns := []string{
+		"/run/media/*/*/SteamLibrary/steamapps/common",
+		"/media/*/*/SteamLibrary/steamapps/common",
+		"/mnt/*/SteamLibrary/steamapps/common",
+	}
+
+	roots := make([]string, 0)
+	seen := make(map[string]bool)
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			continue
+		}
+
+		for _, path := range matches {
+			if seen[path] {
+				continue
+			}
+			if _, err := os.Stat(path); err != nil {
+				continue
+			}
+			seen[path] = true
+			roots = append(roots, path)
+		}
+	}
+
+	return roots
 }


### PR DESCRIPTION
Adds native Linux HOI4 ELF patch support and interactive promptui flow (-dir fallback).
Tested on HOI4 only; EU4/EU5 Linux binaries were not verified on my side.